### PR TITLE
geom_alt props

### DIFF
--- a/data/421/169/045/421169045.geojson
+++ b/data/421/169/045/421169045.geojson
@@ -561,6 +561,9 @@
     },
     "wof:country":"CV",
     "wof:created":1459008792,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70c80e4814c791030181b99593d919da",
     "wof:hierarchy":[
         {
@@ -571,7 +574,7 @@
         }
     ],
     "wof:id":421169045,
-    "wof:lastmodified":1566709941,
+    "wof:lastmodified":1582379123,
     "wof:name":"Praia",
     "wof:parent_id":85670331,
     "wof:placetype":"locality",

--- a/data/856/327/21/85632721.geojson
+++ b/data/856/327/21/85632721.geojson
@@ -1012,6 +1012,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1067,6 +1068,10 @@
     },
     "wof:country":"CV",
     "wof:country_alpha3":"CPV",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"a880a3900456a744663f9fb4c87b4d26",
     "wof:hierarchy":[
         {
@@ -1081,7 +1086,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566709927,
+    "wof:lastmodified":1582379123,
     "wof:name":"Cape Verde",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/327/21/85632721.geojson
+++ b/data/856/327/21/85632721.geojson
@@ -1012,7 +1012,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1086,7 +1085,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1582379123,
+    "wof:lastmodified":1583259851,
     "wof:name":"Cape Verde",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.