### PR TITLE
Name updates

### DIFF
--- a/data/856/327/21/85632721.geojson
+++ b/data/856/327/21/85632721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.348206,
-    "geom:area_square_m":4139442133.679951,
+    "geom:area_square_m":4139442496.684734,
     "geom:bbox":"-25.366278,14.80125,-22.662138,17.210417",
     "geom:latitude":15.948478,
     "geom:longitude":-23.983693,
@@ -59,6 +59,9 @@
     "name:arg_x_preferred":[
         "Cabo Verde"
     ],
+    "name:ary_x_preferred":[
+        "\u0643\u0627\u067e \u06a4\u064a\u0631"
+    ],
     "name:arz_x_preferred":[
         "\u0643\u0627\u0628\u0648 \u0641\u064a\u0631\u062f\u0627"
     ],
@@ -82,6 +85,9 @@
     ],
     "name:bam_x_variant":[
         "Capiv\u025brdi"
+    ],
+    "name:ban_x_preferred":[
+        "Tanjung Gadang"
     ],
     "name:bar_x_preferred":[
         "Kap Verde"
@@ -177,6 +183,12 @@
     "name:dan_x_preferred":[
         "Kap Verde"
     ],
+    "name:deu_at_x_preferred":[
+        "Kap Verde"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Kap Verde"
+    ],
     "name:deu_x_preferred":[
         "Kap Verde"
     ],
@@ -202,6 +214,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a0\u03c1\u03ac\u03c3\u03b9\u03bd\u03bf \u0391\u03ba\u03c1\u03c9\u03c4\u03ae\u03c1\u03b9\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Cape Verde"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Cape Verde"
     ],
     "name:eng_x_preferred":[
         "Cape Verde"
@@ -278,6 +296,9 @@
     ],
     "name:gag_x_preferred":[
         "Kabo Verde"
+    ],
+    "name:gcr_x_preferred":[
+        "Kap-V\u00e8r"
     ],
     "name:gla_x_preferred":[
         "Cape Verde"
@@ -546,6 +567,9 @@
     "name:mlt_x_variant":[
         "Kape Verde"
     ],
+    "name:mon_x_preferred":[
+        "\u041a\u0430\u0431\u043e-\u0412\u0435\u0440\u0434\u0435"
+    ],
     "name:mri_x_preferred":[
         "K\u0113pa Weriti"
     ],
@@ -612,6 +636,9 @@
     "name:nov_x_preferred":[
         "Kabe Verdi"
     ],
+    "name:nqo_x_preferred":[
+        "\u07dc\u07d9\u07cb\u07de\u07ce\u07f2\u07eb \u07dd\u07d9\u07cc\u07db\u07cc"
+    ],
     "name:nrm_x_preferred":[
         "V\u00e8rt Cap"
     ],
@@ -662,6 +689,9 @@
     ],
     "name:pol_x_variant":[
         "Wyspy Zielonego Przyl\u0105dka"
+    ],
+    "name:por_br_x_preferred":[
+        "Cabo Verde"
     ],
     "name:por_x_preferred":[
         "Cabo Verde"
@@ -917,11 +947,32 @@
     "name:yue_x_preferred":[
         "\u7dad\u5fb7\u89d2"
     ],
+    "name:zea_x_preferred":[
+        "Kaopverdi\u00eb"
+    ],
     "name:zha_x_preferred":[
         "Cabo Verde"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u4f5b\u5f97\u89d2"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7dad\u5fb7\u89d2"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Chhe\u207f-kak Ki\u014dng-h\u00f4-kok"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u4f5b\u5f97\u89d2"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u4f5b\u5f97\u89d2"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u4f5b\u5f97\u89d2"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u7dad\u5fb7\u89d2"
     ],
     "name:zho_x_preferred":[
         "\u4f5b\u5f97\u89d2"
@@ -1086,7 +1137,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1583797317,
+    "wof:lastmodified":1587428706,
     "wof:name":"Cape Verde",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.