### PR TITLE
cv concordances, placetype local, and more

### DIFF
--- a/data/856/327/21/85632721.geojson
+++ b/data/856/327/21/85632721.geojson
@@ -1244,6 +1244,7 @@
         "hasc:id":"CV",
         "icao:code":"D4",
         "ioc:id":"CPV",
+        "iso:code":"CV",
         "itu:id":"CPV",
         "loc:id":"n81141822",
         "m49:code":"132",
@@ -1258,6 +1259,7 @@
         "wk:page":"Cape Verde",
         "wmo:id":"CV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
     "wof:country_alpha3":"CPV",
     "wof:geom_alt":[
@@ -1278,7 +1280,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694639670,
+    "wof:lastmodified":1695881329,
     "wof:name":"Cape Verde",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/702/79/85670279.geojson
+++ b/data/856/702/79/85670279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00502,
-    "geom:area_square_m":60001796.943768,
+    "geom:area_square_m":60001570.849271,
     "geom:bbox":"-24.758941,14.803941,-24.683258,14.900824",
     "geom:latitude":14.854187,
     "geom:longitude":-24.717711,
@@ -254,13 +254,15 @@
         "gn:id":3374832,
         "gp:id":2345122,
         "hasc:id":"CV.BR",
+        "iso:code":"CV-BR",
         "iso:id":"CV-BR",
         "qs_pg:id":1083817,
         "wd:id":"Q2571624",
         "wk:page":"Brava, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"3cc3b5079991db7a9a3fc8ea0fb1bce4",
+    "wof:geomhash":"4deafa7f0cb57f30343d135c194062a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -275,7 +277,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868581,
+    "wof:lastmodified":1695884956,
     "wof:name":"Brava",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/702/83/85670283.geojson
+++ b/data/856/702/83/85670283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024485,
-    "geom:area_square_m":292563908.631472,
+    "geom:area_square_m":292564409.520266,
     "geom:bbox":"-24.526235,14.815985,-24.292836,15.025015",
     "geom:latitude":14.909571,
     "geom:longitude":-24.427909,
@@ -259,14 +259,16 @@
         "gn:id":3411927,
         "gp:id":56051564,
         "hasc:id":"CV.FP",
+        "iso:code":"CV-SF",
         "iso:id":"CV-SF",
         "qs_pg:id":1086865,
         "unlc:id":"CV-SF",
         "wd:id":"Q6430079",
         "wk:page":"S\u00e3o Filipe, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"f365b96e2f5254e3f01f39c7e7309d92",
+    "wof:geomhash":"1537f380d4274f1394ed80bdbf2cb149",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -281,7 +283,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868582,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Filipe",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/702/87/85670287.geojson
+++ b/data/856/702/87/85670287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008237,
-    "geom:area_square_m":98380772.398645,
+    "geom:area_square_m":98380561.994644,
     "geom:bbox":"-24.429691,14.944918,-24.301476,15.045396",
     "geom:latitude":14.997078,
     "geom:longitude":-24.362068,
@@ -252,14 +252,16 @@
         "gn:id":3411924,
         "gp:id":56051566,
         "hasc:id":"CV.MO",
+        "iso:code":"CV-MO",
         "iso:id":"CV-MO",
         "qs_pg:id":896710,
         "unlc:id":"CV-MO",
         "wd:id":"Q516835",
         "wk:page":"Mosteiros, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"8f33c3f7a30c4a325f38d30090a24234",
+    "wof:geomhash":"cf799c186d969e85b1e11bb1e3fddef3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868581,
+    "wof:lastmodified":1695884956,
     "wof:name":"Mosteiros",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/702/93/85670293.geojson
+++ b/data/856/702/93/85670293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00594,
-    "geom:area_square_m":70977785.748993,
+    "geom:area_square_m":70977517.683215,
     "geom:bbox":"-24.383431,14.869565,-24.295766,14.954846",
     "geom:latitude":14.913944,
     "geom:longitude":-24.338084,
@@ -217,14 +217,16 @@
         "gn:id":7602870,
         "gp:id":56051565,
         "hasc:id":"CV.CF",
+        "iso:code":"CV-CF",
         "iso:id":"CV-CF",
         "qs_pg:id":78463,
         "unlc:id":"CV-CF",
         "wd:id":"Q2608046",
         "wk:page":"Santa Catarina do Fogo, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"897d9f9599888c67ef899c111243c867",
+    "wof:geomhash":"60aa89599c3072c53badb6236a6156f1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -239,7 +241,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868581,
+    "wof:lastmodified":1695884956,
     "wof:name":"Santa Catarina do Fogo",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/702/99/85670299.geojson
+++ b/data/856/702/99/85670299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011308,
-    "geom:area_square_m":134901736.159747,
+    "geom:area_square_m":134902128.783762,
     "geom:bbox":"-23.785756,15.179966,-23.648549,15.33275",
     "geom:latitude":15.247058,
     "geom:longitude":-23.722695,
@@ -263,13 +263,15 @@
         "gn:id":3374161,
         "gp:id":2345131,
         "hasc:id":"CV.TF",
+        "iso:code":"CV-TA",
         "iso:id":"CV-TA",
         "qs_pg:id":219538,
         "wd:id":"Q499598",
         "wk:page":"Tarrafal, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"0a45889ee66b00f63f3e85d420b402ba",
+    "wof:geomhash":"7097dca3d45907f4d4245ab88e91ffbf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868581,
+    "wof:lastmodified":1695884956,
     "wof:name":"Tarrafal",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/01/85670301.geojson
+++ b/data/856/703/01/85670301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023426,
-    "geom:area_square_m":279676699.303979,
+    "geom:area_square_m":279676726.296159,
     "geom:bbox":"-23.792592,14.968451,-23.618338,15.184396",
     "geom:latitude":15.087876,
     "geom:longitude":-23.709657,
@@ -264,13 +264,15 @@
         "gn:id":3374226,
         "gp:id":2345128,
         "hasc:id":"CV.CT",
+        "iso:code":"CV-CA",
         "iso:id":"CV-CA",
         "qs_pg:id":984075,
         "wd:id":"Q494882",
         "wk:page":"Santa Catarina, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"15a7c6c24b19e17eaa99f0090dcd6014",
+    "wof:geomhash":"74fd3aebecb4bd7279a1b0a6e784b018",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868584,
+    "wof:lastmodified":1695884956,
     "wof:name":"Santa Catarina",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/05/85670305.geojson
+++ b/data/856/703/05/85670305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005903,
-    "geom:area_square_m":70451228.565104,
+    "geom:area_square_m":70451375.742483,
     "geom:bbox":"-23.68699,15.119065,-23.591601,15.229722",
     "geom:latitude":15.175676,
     "geom:longitude":-23.642531,
@@ -209,14 +209,16 @@
         "gn:id":3411928,
         "gp:id":56051558,
         "hasc:id":"CV.SM",
+        "iso:code":"CV-SM",
         "iso:id":"CV-SM",
         "qs_pg:id":1105207,
         "unlc:id":"CV-SM",
         "wd:id":"Q494874",
         "wk:page":"S\u00e3o Miguel, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"20d1a0c4328f89cbf46751d96f8cbe36",
+    "wof:geomhash":"80b8e30b63e56f93d71689a79789ca23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +233,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868583,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Miguel",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/11/85670311.geojson
+++ b/data/856/703/11/85670311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008228,
-    "geom:area_square_m":98218951.009098,
+    "geom:area_square_m":98218062.300606,
     "geom:bbox":"-23.6266,15.045984,-23.484659,15.170212",
     "geom:latitude":15.108741,
     "geom:longitude":-23.554925,
@@ -292,12 +292,14 @@
         "gn:id":3411925,
         "gp:id":56051561,
         "hasc:id":"CV.CZ",
+        "iso:code":"CV-CR",
         "iso:id":"CV-CR",
         "qs_pg:id":989677,
         "unlc:id":"CV-CR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"4dc5f0f8111fd6ad9404836bbb1f406d",
+    "wof:geomhash":"b582b22b54c935859ef2bef3a66a2f63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1636504678,
+    "wof:lastmodified":1695884956,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/15/85670315.geojson
+++ b/data/856/703/15/85670315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003381,
-    "geom:area_square_m":40368835.515069,
+    "geom:area_square_m":40368853.81945,
     "geom:bbox":"-23.647959,15.03934,-23.578475,15.105778",
     "geom:latitude":15.073006,
     "geom:longitude":-23.612637,
@@ -209,14 +209,16 @@
         "gn:id":7602871,
         "gp:id":56051557,
         "hasc:id":"CV.SS",
+        "iso:code":"CV-SS",
         "iso:id":"CV-SS",
         "qs_pg:id":1002263,
         "unlc:id":"CV-SS",
         "wd:id":"Q494877",
         "wk:page":"S\u00e3o Salvador do Mundo, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"d21e1a9723684e402bb660dec17fb95d",
+    "wof:geomhash":"d91d0302b1758c776cae030dc09693b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +233,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868585,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Salvador do Mundo",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/19/85670319.geojson
+++ b/data/856/703/19/85670319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002688,
-    "geom:area_square_m":32093451.229655,
+    "geom:area_square_m":32093682.998522,
     "geom:bbox":"-23.612039,15.011658,-23.526432,15.081557",
     "geom:latitude":15.048226,
     "geom:longitude":-23.574119,
@@ -244,13 +244,15 @@
         "gn:id":7602873,
         "gp:id":56051560,
         "hasc:id":"CV.LO",
+        "iso:code":"CV-SO",
         "iso:id":"CV-SO",
         "qs_pg:id":917915,
         "unlc:id":"CV-SO",
         "wd:id":"Q494726"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"e4aa4cd7d9cc2a0d8155724ac3d10019",
+    "wof:geomhash":"e869de339b8f907b5b77c2d79b344e26",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -265,7 +267,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868583,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Louren\u00e7o dos \u00d3rg\u00e3os",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/21/85670321.geojson
+++ b/data/856/703/21/85670321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009493,
-    "geom:area_square_m":113372313.604379,
+    "geom:area_square_m":113372672.451033,
     "geom:bbox":"-23.596192,14.960723,-23.443105,15.064038",
     "geom:latitude":15.009811,
     "geom:longitude":-23.520709,
@@ -265,14 +265,16 @@
         "gn:id":3411926,
         "gp:id":56051562,
         "hasc:id":"CV.SD",
+        "iso:code":"CV-SD",
         "iso:id":"CV-SD",
         "qs_pg:id":78470,
         "unlc:id":"CV-SD",
         "wd:id":"Q499009",
         "wk:page":"S\u00e3o Domingos, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"32f6463f8c3ffd37ba020b9da193419b",
+    "wof:geomhash":"5c524b3a2a70a4b0d37db34eb6d8bb9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868583,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Domingos",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/27/85670327.geojson
+++ b/data/856/703/27/85670327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011739,
-    "geom:area_square_m":140235388.66632,
+    "geom:area_square_m":140235049.9362,
     "geom:bbox":"-23.715077,14.90762,-23.539296,15.04092",
     "geom:latitude":14.965994,
     "geom:longitude":-23.62659,
@@ -191,13 +191,15 @@
         "gn:id":3374274,
         "gp:id":56051563,
         "hasc:id":"CV.RS",
+        "iso:code":"CV-RS",
         "iso:id":"CV-RS",
         "qs_pg:id":9360,
         "unlc:id":"CV-RS",
         "wk:page":"Ribeira Grande, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"3dea6d9db7f7e139a20b095790d8c5be",
+    "wof:geomhash":"f9ec24d4a51915408e78e87abcaaac72",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -212,7 +214,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1636504678,
+    "wof:lastmodified":1695884956,
     "wof:name":"Ribeira Grande de Santiago",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/31/85670331.geojson
+++ b/data/856/703/31/85670331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004652,
-    "geom:area_square_m":55572240.289565,
+    "geom:area_square_m":55572240.289557,
     "geom:bbox":"-23.56408,14.90762,-23.470448,14.98619",
     "geom:latitude":14.947615,
     "geom:longitude":-23.51589,
@@ -270,17 +270,19 @@
         "gn:id":3374332,
         "gp:id":2345125,
         "hasc:id":"CV.PC",
+        "iso:code":"CV-PR",
         "iso:id":"CV-PR",
         "qs_pg:id":235576,
         "unlc:id":"CV-PR",
         "wd:id":"Q497019",
         "wk:page":"Praia, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421169045
     ],
     "wof:country":"CV",
-    "wof:geomhash":"4c66d30340c6502252da823900d3aacf",
+    "wof:geomhash":"23e2bf7cad99e6cac1c45a10943e8d7d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868583,
+    "wof:lastmodified":1695884956,
     "wof:name":"Praia",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/35/85670335.geojson
+++ b/data/856/703/35/85670335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022613,
-    "geom:area_square_m":269801272.035397,
+    "geom:area_square_m":269801531.492755,
     "geom:bbox":"-23.258168,15.118598,-23.110463,15.33275",
     "geom:latitude":15.221338,
     "geom:longitude":-23.18038,
@@ -219,14 +219,16 @@
         "gn:id":3374487,
         "gp:id":2345124,
         "hasc:id":"CV.MA",
+        "iso:code":"CV-MA",
         "iso:id":"CV-MA",
         "qs_pg:id":894873,
         "unlc:id":"CV-MA",
         "wd:id":"Q2551133",
         "wk:page":"Maio, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"bad8db5aaced57ea94c2126d54b3d493",
+    "wof:geomhash":"aa7c641078b2bf3f1c83773c6505446a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -241,7 +243,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868582,
+    "wof:lastmodified":1695884956,
     "wof:name":"Maio",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/39/85670339.geojson
+++ b/data/856/703/39/85670339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053689,
-    "geom:area_square_m":637816214.873789,
+    "geom:area_square_m":637817114.982735,
     "geom:bbox":"-22.963979,15.982367,-22.666575,16.243964",
     "geom:latitude":16.10576,
     "geom:longitude":-22.816875,
@@ -265,14 +265,16 @@
         "gn:id":3374855,
         "gp:id":2345121,
         "hasc:id":"CV.BV",
+        "iso:code":"CV-BV",
         "iso:id":"CV-BV",
         "qs_pg:id":1083816,
         "unlc:id":"CV-BV",
         "wd:id":"Q110440",
         "wk:page":"Boa Vista, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"2c5d0d5bec2fc096719bbaf298b16193",
+    "wof:geomhash":"0fb4df9f88531388f7b6f063664adde6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868584,
+    "wof:lastmodified":1695884956,
     "wof:name":"Boa Vista",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/41/85670341.geojson
+++ b/data/856/703/41/85670341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016879,
-    "geom:area_square_m":199873036.645347,
+    "geom:area_square_m":199873883.675832,
     "geom:bbox":"-22.991567,16.593411,-22.881337,16.860297",
     "geom:latitude":16.739307,
     "geom:longitude":-22.934483,
@@ -258,14 +258,16 @@
         "gn:id":3374249,
         "gp:id":2345127,
         "hasc:id":"CV.SL",
+        "iso:code":"CV-SL",
         "iso:id":"CV-SL",
         "qs_pg:id":1083820,
         "unlc:id":"CV-SL",
         "wd:id":"Q2721003",
         "wk:page":"Sal, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"51a13fd31a5e54e01b37aa92ade6aa68",
+    "wof:geomhash":"d07ad3eb4e88c187f1915427d9f5f441",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -280,7 +282,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868585,
+    "wof:lastmodified":1695884956,
     "wof:name":"Sal",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/47/85670347.geojson
+++ b/data/856/703/47/85670347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019455,
-    "geom:area_square_m":230535295.978851,
+    "geom:area_square_m":230534046.166719,
     "geom:bbox":"-24.376535,16.482652,-24.032826,16.681586",
     "geom:latitude":16.606457,
     "geom:longitude":-24.212297,
@@ -258,14 +258,16 @@
         "gn:id":7602869,
         "gp:id":56051567,
         "hasc:id":"CV.RB",
+        "iso:code":"CV-RB",
         "iso:id":"CV-RB",
         "qs_pg:id":989678,
         "unlc:id":"CV-RB",
         "wd:id":"Q747221",
         "wk:page":"Ribeira Brava, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"d6ab5ace2704a47090fd1a421ae7ac50",
+    "wof:geomhash":"4f0c70b10b06b023b3b31a342aa6b5b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -280,7 +282,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868585,
+    "wof:lastmodified":1695884956,
     "wof:name":"Ribeira Brava",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/51/85670351.geojson
+++ b/data/856/703/51/85670351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00898,
-    "geom:area_square_m":106408762.283602,
+    "geom:area_square_m":106408762.283624,
     "geom:bbox":"-24.4306534501,16.4826520853,-24.314417823,16.6771229631",
     "geom:latitude":16.600347,
     "geom:longitude":-24.365787,
@@ -206,14 +206,16 @@
         "gn:id":7602872,
         "gp:id":2345129,
         "hasc:id":"CV.TS",
+        "iso:code":"CV-TS",
         "iso:id":"CV-TS",
         "qs_pg:id":984076,
         "unlc:id":"CV-TS",
         "wd:id":"Q1895853",
         "wk:page":"Tarrafal de S\u00e3o Nicolau, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"f87189787deb339f68b2fbc78968ee46",
+    "wof:geomhash":"c537826eb17da6c5a9c594a33c5933d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +230,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566709926,
+    "wof:lastmodified":1695884329,
     "wof:name":"Tarrafal de S\u00e3o Nicolau",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/55/85670355.geojson
+++ b/data/856/703/55/85670355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022407,
-    "geom:area_square_m":265191681.516188,
+    "geom:area_square_m":265191486.226177,
     "geom:bbox":"-25.094146,16.605505,-24.569512,16.923",
     "geom:latitude":16.832448,
     "geom:longitude":-24.936654,
@@ -262,14 +262,16 @@
         "gn:id":3374198,
         "gp:id":2345130,
         "hasc:id":"CV.SV",
+        "iso:code":"CV-SV",
         "iso:id":"CV-SV",
         "qs_pg:id":219537,
         "unlc:id":"CV-SV",
         "wd:id":"Q648842",
         "wk:page":"S\u00e3o Vicente, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"c7301ac79150d6b55f693bf6adb56dd5",
+    "wof:geomhash":"6d0502a332b136e85d97a3d9aaf0fbee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868584,
+    "wof:lastmodified":1695884329,
     "wof:name":"S\u00e3o Vicente",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/59/85670359.geojson
+++ b/data/856/703/59/85670359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046096,
-    "geom:area_square_m":544980730.161276,
+    "geom:area_square_m":544981327.707164,
     "geom:bbox":"-25.360422,16.917182,-24.986682,17.136705",
     "geom:latitude":17.032895,
     "geom:longitude":-25.198292,
@@ -148,12 +148,14 @@
         "gn:id":7602868,
         "gp:id":56051556,
         "hasc:id":"CV.PN",
+        "iso:code":"CV-PN",
         "iso:id":"CV-PN",
         "qs_pg:id":1119144,
         "unlc:id":"CV-PN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"623af6f8a15c02c18187763e3da72496",
+    "wof:geomhash":"40272a6470b29643cbae4dfe1100f5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +170,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1636504677,
+    "wof:lastmodified":1695884956,
     "wof:name":"Porto Novo",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/63/85670363.geojson
+++ b/data/856/703/63/85670363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013684,
-    "geom:area_square_m":161685294.86958,
+    "geom:area_square_m":161685303.141483,
     "geom:bbox":"-25.245351,17.085776,-25.025868,17.196601",
     "geom:latitude":17.143427,
     "geom:longitude":-25.124874,
@@ -263,13 +263,15 @@
         "gn:id":3374274,
         "gp:id":2345126,
         "hasc:id":"CV.RG",
+        "iso:code":"CV-RG",
         "iso:id":"CV-RG",
         "qs_pg:id":1083819,
         "wd:id":"Q1355642",
         "wk:page":"Ribeira Grande, Cape Verde (municipality)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"2257d66c553e0917e817c56c8cd9f4fb",
+    "wof:geomhash":"5a43ea03860949a4fbb4ee3305e69679",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868584,
+    "wof:lastmodified":1695884956,
     "wof:name":"Ribeira Grande",
     "wof:parent_id":85632721,
     "wof:placetype":"region",

--- a/data/856/703/69/85670369.geojson
+++ b/data/856/703/69/85670369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003175,
-    "geom:area_square_m":37520900.572057,
+    "geom:area_square_m":37521057.887211,
     "geom:bbox":"-25.072976,17.078865,-24.971262,17.144924",
     "geom:latitude":17.114427,
     "geom:longitude":-25.01333,
@@ -277,6 +277,7 @@
         "gn:id":3374391,
         "gp:id":20069964,
         "hasc:id":"CV.PA",
+        "iso:code":"CV-PA",
         "iso:id":"CV-PA",
         "loc:id":"no2014070592",
         "qs_pg:id":902458,
@@ -284,8 +285,9 @@
         "wd:id":"Q1475374",
         "wk:page":"Paul, Cape Verde"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CV",
-    "wof:geomhash":"dd45bfe2a0a11bcfb66cbef5097eee4c",
+    "wof:geomhash":"9647b6084218c6f4478b270fb52c759e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690868582,
+    "wof:lastmodified":1695884956,
     "wof:name":"Paul",
     "wof:parent_id":85632721,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.